### PR TITLE
Switched to singular contest for contests label. 

### DIFF
--- a/openq-api/getCategory.js
+++ b/openq-api/getCategory.js
@@ -6,7 +6,7 @@ const getCategory = (labels, type) => {
 	if (type === "1" && labels?.some(label => label === "learn2earn")) {
 		return "learn2earn";
 	}
-	if ((type === "2" || type === "3") && labels?.some(label => label === "contests")) {
+	if ((type === "2" || type === "3") && labels?.some(label => label === "contest")) {
 		return "contest";
 	}
 	return undefined;


### PR DESCRIPTION
Now categorizes bounties as contests only if they have the label: "contest", formerly it would only categorize them as contests if they had the label "contests"